### PR TITLE
Add basic crypto portfolio server and client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "datafollow",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "datafollow",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "datafollow",
+  "version": "1.0.0",
+  "description": "Follow Crypto value",
+  "main": "server/index.js",
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "echo 'No tests specified'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Portefeuille Crypto</title>
+</head>
+<body>
+  <h1>Portefeuille Crypto</h1>
+  <button id="add-crypto">+</button>
+  <table border="1">
+    <thead>
+      <tr>
+        <th>Crypto</th>
+        <th>Valeur (EUR)</th>
+        <th>Valeur (USD)</th>
+      </tr>
+    </thead>
+    <tbody id="portfolio-body"></tbody>
+  </table>
+
+  <script src="js/portfolio.js"></script>
+</body>
+</html>

--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -1,0 +1,73 @@
+const tbody = document.getElementById('portfolio-body');
+const addBtn = document.getElementById('add-crypto');
+
+function savePortfolio() {
+  const cryptos = Array.from(tbody.querySelectorAll('input.crypto-name'))
+    .map(input => input.value.trim())
+    .filter(Boolean);
+  localStorage.setItem('portfolio', JSON.stringify(cryptos));
+}
+
+function addRow(name = '') {
+  const row = document.createElement('tr');
+
+  const nameCell = document.createElement('td');
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameInput.value = name;
+  nameInput.classList.add('crypto-name');
+  nameCell.appendChild(nameInput);
+  row.appendChild(nameCell);
+
+  const eurCell = document.createElement('td');
+  eurCell.textContent = '-';
+  row.appendChild(eurCell);
+
+  const usdCell = document.createElement('td');
+  usdCell.textContent = '-';
+  row.appendChild(usdCell);
+
+  function update() {
+    const crypto = nameInput.value.trim().toLowerCase();
+    if (!crypto) {
+      eurCell.textContent = '-';
+      usdCell.textContent = '-';
+      savePortfolio();
+      return;
+    }
+    fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${crypto}&vs_currencies=eur,usd`)
+      .then(res => res.json())
+      .then(data => {
+        if (data[crypto]) {
+          eurCell.textContent = data[crypto].eur;
+          usdCell.textContent = data[crypto].usd;
+        } else {
+          eurCell.textContent = 'N/A';
+          usdCell.textContent = 'N/A';
+        }
+      })
+      .catch(() => {
+        eurCell.textContent = 'Err';
+        usdCell.textContent = 'Err';
+      })
+      .finally(savePortfolio);
+  }
+
+  nameInput.addEventListener('change', update);
+  tbody.appendChild(row);
+
+  if (name) {
+    update();
+  }
+}
+
+addBtn.addEventListener('click', () => addRow());
+
+(function init() {
+  const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
+  if (saved.length) {
+    saved.forEach(name => addRow(name));
+  } else {
+    addRow();
+  }
+})();

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,37 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.join(__dirname, '..', 'public');
+
+function serveStatic(filePath, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = {
+      '.html': 'text/html',
+      '.js': 'application/javascript',
+      '.css': 'text/css',
+      '.json': 'application/json'
+    }[ext] || 'text/plain';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  let filePath = path.join(publicDir, req.url);
+  if (req.url === '/' || req.url === '') {
+    filePath = path.join(publicDir, 'index.html');
+  }
+  serveStatic(filePath, res);
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- serve static `public/` assets via simple Node HTTP server
- build HTML table with dynamic crypto rows and add button
- fetch EUR/USD prices for entered cryptos and store selections locally

## Testing
- `npm test`
- `node server/index.js` (manually terminated)


------
https://chatgpt.com/codex/tasks/task_e_68c6d6da65cc832abd5f93973fda2be2