### PR TITLE
feat: add crypto dropdown menu

### DIFF
--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -1,22 +1,39 @@
 const tbody = document.getElementById('portfolio-body');
 const addBtn = document.getElementById('add-crypto');
+let coinList = [];
 
 function savePortfolio() {
-  const cryptos = Array.from(tbody.querySelectorAll('input.crypto-name'))
-    .map(input => input.value.trim())
+  const cryptos = Array.from(tbody.querySelectorAll('select.crypto-name'))
+    .map(select => select.value.trim())
     .filter(Boolean);
   localStorage.setItem('portfolio', JSON.stringify(cryptos));
+}
+
+function populateSelect(select, selected = '') {
+  const emptyOption = document.createElement('option');
+  emptyOption.value = '';
+  emptyOption.textContent = '';
+  select.appendChild(emptyOption);
+
+  coinList.forEach(coin => {
+    const option = document.createElement('option');
+    option.value = coin.id;
+    option.textContent = coin.symbol.toUpperCase();
+    if (coin.id === selected) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
 }
 
 function addRow(name = '') {
   const row = document.createElement('tr');
 
   const nameCell = document.createElement('td');
-  const nameInput = document.createElement('input');
-  nameInput.type = 'text';
-  nameInput.value = name;
-  nameInput.classList.add('crypto-name');
-  nameCell.appendChild(nameInput);
+  const nameSelect = document.createElement('select');
+  nameSelect.classList.add('crypto-name');
+  populateSelect(nameSelect, name);
+  nameCell.appendChild(nameSelect);
   row.appendChild(nameCell);
 
   const eurCell = document.createElement('td');
@@ -28,7 +45,7 @@ function addRow(name = '') {
   row.appendChild(usdCell);
 
   function update() {
-    const crypto = nameInput.value.trim().toLowerCase();
+    const crypto = nameSelect.value.trim().toLowerCase();
     if (!crypto) {
       eurCell.textContent = '-';
       usdCell.textContent = '-';
@@ -53,7 +70,7 @@ function addRow(name = '') {
       .finally(savePortfolio);
   }
 
-  nameInput.addEventListener('change', update);
+  nameSelect.addEventListener('change', update);
   tbody.appendChild(row);
 
   if (name) {
@@ -64,10 +81,15 @@ function addRow(name = '') {
 addBtn.addEventListener('click', () => addRow());
 
 (function init() {
-  const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
-  if (saved.length) {
-    saved.forEach(name => addRow(name));
-  } else {
-    addRow();
-  }
+  fetch('https://api.coingecko.com/api/v3/coins/list')
+    .then(res => res.json())
+    .then(data => {
+      coinList = data;
+      const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
+      if (saved.length) {
+        saved.forEach(name => addRow(name));
+      } else {
+        addRow();
+      }
+    });
 })();


### PR DESCRIPTION
## Summary
- replace crypto text input with dropdown of all coins via CoinGecko API
- allow blank selection so rows start unselected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6dc07ebb8832a8b7764fc46e34fbc