### PR TITLE
Add save button for portfolio

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,7 @@
     <tbody id="portfolio-body"></tbody>
   </table>
   <button id="add-crypto">+</button>
+  <button id="save-portfolio">Sauvegarder</button>
   <script src="js/portfolio.js"></script>
 </body>
 </html>

--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -1,5 +1,6 @@
 const tbody = document.getElementById('portfolio-body');
 const addBtn = document.getElementById('add-crypto');
+const saveBtn = document.getElementById('save-portfolio');
 let coinList = [];
 
 function savePortfolio() {
@@ -79,6 +80,7 @@ function addRow(name = '') {
 }
 
 addBtn.addEventListener('click', () => addRow());
+saveBtn.addEventListener('click', savePortfolio);
 
 (function init() {
   fetch('https://api.coingecko.com/api/v3/coins/list')


### PR DESCRIPTION
## Summary
- Add explicit save button to persist selected cryptocurrencies in browser storage
- Wire save button to existing save logic

## Testing
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68c6dd9986fc832a8068875108bc8e95