### PR TITLE
Add top menu and purchase entry page

### DIFF
--- a/public/achat.html
+++ b/public/achat.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Achat Crypto</title>
+</head>
+<body>
+  <nav>
+    <a href="/">Accueil</a> |
+    <a href="achat.html">Achat</a>
+  </nav>
+  <h1>Enregistrer un achat</h1>
+  <form id="achat-form">
+    <label>Crypto:
+      <select id="crypto-select"></select>
+    </label>
+    <label>Quantité:
+      <input type="number" id="quantity" step="any" required />
+    </label>
+    <label>Prix (EUR):
+      <input type="number" id="price" step="any" required />
+    </label>
+    <button type="submit">Ajouter</button>
+  </form>
+
+  <h2>Achats enregistrés</h2>
+  <table border="1">
+    <thead>
+      <tr>
+        <th>Crypto</th>
+        <th>Quantité</th>
+        <th>Prix (EUR)</th>
+      </tr>
+    </thead>
+    <tbody id="purchases-body"></tbody>
+  </table>
+
+  <script src="js/achat.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,10 @@
   <title>Portefeuille Crypto</title>
 </head>
 <body>
+  <nav>
+    <a href="/">Accueil</a> |
+    <a href="achat.html">Achat</a>
+  </nav>
   <h1>Portefeuille Crypto</h1>
   
   <table border="1">

--- a/public/js/achat.js
+++ b/public/js/achat.js
@@ -1,0 +1,65 @@
+const select = document.getElementById('crypto-select');
+const form = document.getElementById('achat-form');
+const body = document.getElementById('purchases-body');
+let coinList = [];
+
+function populateSelect() {
+  const emptyOption = document.createElement('option');
+  emptyOption.value = '';
+  emptyOption.textContent = '';
+  select.appendChild(emptyOption);
+
+  coinList.forEach(coin => {
+    const option = document.createElement('option');
+    option.value = coin.id;
+    option.textContent = coin.symbol.toUpperCase();
+    select.appendChild(option);
+  });
+}
+
+function save() {
+  const purchases = Array.from(body.querySelectorAll('tr')).map(row => ({
+    crypto: row.children[0].textContent,
+    quantity: row.children[1].textContent,
+    price: row.children[2].textContent
+  }));
+  localStorage.setItem('purchases', JSON.stringify(purchases));
+}
+
+function addRow({ crypto, quantity, price }) {
+  const row = document.createElement('tr');
+  const cCell = document.createElement('td');
+  cCell.textContent = crypto;
+  row.appendChild(cCell);
+  const qCell = document.createElement('td');
+  qCell.textContent = quantity;
+  row.appendChild(qCell);
+  const pCell = document.createElement('td');
+  pCell.textContent = price;
+  row.appendChild(pCell);
+  body.appendChild(row);
+}
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const crypto = select.value.trim();
+  const quantity = document.getElementById('quantity').value;
+  const price = document.getElementById('price').value;
+  if (!crypto || !quantity || !price) return;
+
+  const symbol = select.options[select.selectedIndex].textContent;
+  addRow({ crypto: symbol, quantity, price });
+  save();
+  form.reset();
+});
+
+(function init() {
+  fetch('https://api.coingecko.com/api/v3/coins/list')
+    .then(res => res.json())
+    .then(data => {
+      coinList = data;
+      populateSelect();
+      const saved = JSON.parse(localStorage.getItem('purchases') || '[]');
+      saved.forEach(addRow);
+    });
+})();


### PR DESCRIPTION
## Summary
- Add navigation menu linking to portfolio and purchase entry pages
- Implement purchase recording page with local storage persistence
- Provide script to manage crypto purchase entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6dded1aa0832aab4bb820ee7ccded