### PR TITLE
Add crypto purchase tracking and profit analysis

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,33 @@
     <thead>
       <tr>
         <th>Crypto</th>
-        <th>Valeur (EUR)</th>
-        <th>Valeur (USD)</th>
+        <th>Date</th>
+        <th>Quantité</th>
+        <th>Prix d'achat</th>
+        <th>Devise</th>
+        <th>Coût</th>
+        <th>Valeur actuelle</th>
+        <th>Différence</th>
+        <th>%</th>
       </tr>
     </thead>
     <tbody id="portfolio-body"></tbody>
+    <tfoot>
+      <tr>
+        <th colspan="5">Total EUR</th>
+        <th id="total-eur-cost">0</th>
+        <th id="total-eur-value">0</th>
+        <th id="total-eur-diff">0</th>
+        <th id="total-eur-percent">0%</th>
+      </tr>
+      <tr>
+        <th colspan="5">Total USD</th>
+        <th id="total-usd-cost">0</th>
+        <th id="total-usd-value">0</th>
+        <th id="total-usd-diff">0</th>
+        <th id="total-usd-percent">0%</th>
+      </tr>
+    </tfoot>
   </table>
   <button id="add-crypto">+</button>
   <script src="js/portfolio.js"></script>

--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -3,10 +3,37 @@ const addBtn = document.getElementById('add-crypto');
 let coinList = [];
 
 function savePortfolio() {
-  const cryptos = Array.from(tbody.querySelectorAll('select.crypto-name'))
-    .map(select => select.value.trim())
-    .filter(Boolean);
-  localStorage.setItem('portfolio', JSON.stringify(cryptos));
+  const items = Array.from(tbody.querySelectorAll('tr')).map(row => {
+    return {
+      id: row.querySelector('select.crypto-name').value.trim(),
+      date: row.querySelector('input.purchase-date').value,
+      amount: row.querySelector('input.amount').value,
+      price: row.querySelector('input.price').value,
+      currency: row.querySelector('select.currency').value
+    };
+  }).filter(item => item.id);
+  localStorage.setItem('portfolio', JSON.stringify(items));
+}
+
+function updateTotals() {
+  const totals = { eur: { cost: 0, value: 0 }, usd: { cost: 0, value: 0 } };
+  Array.from(tbody.querySelectorAll('tr')).forEach(row => {
+    const cur = row.querySelector('select.currency').value;
+    const cost = parseFloat(row.dataset.cost || '0');
+    const value = parseFloat(row.dataset.value || '0');
+    totals[cur].cost += cost;
+    totals[cur].value += value;
+  });
+  ['eur', 'usd'].forEach(cur => {
+    const cost = totals[cur].cost;
+    const value = totals[cur].value;
+    const diff = value - cost;
+    const percent = cost ? (diff / cost) * 100 : 0;
+    document.getElementById(`total-${cur}-cost`).textContent = cost.toFixed(2);
+    document.getElementById(`total-${cur}-value`).textContent = value.toFixed(2);
+    document.getElementById(`total-${cur}-diff`).textContent = diff.toFixed(2);
+    document.getElementById(`total-${cur}-percent`).textContent = percent.toFixed(2) + '%';
+  });
 }
 
 function populateSelect(select, selected = '') {
@@ -26,54 +53,135 @@ function populateSelect(select, selected = '') {
   });
 }
 
-function addRow(name = '') {
+function addRow(data = {}) {
   const row = document.createElement('tr');
 
   const nameCell = document.createElement('td');
   const nameSelect = document.createElement('select');
   nameSelect.classList.add('crypto-name');
-  populateSelect(nameSelect, name);
+  populateSelect(nameSelect, data.id || '');
   nameCell.appendChild(nameSelect);
   row.appendChild(nameCell);
 
-  const eurCell = document.createElement('td');
-  eurCell.textContent = '-';
-  row.appendChild(eurCell);
+  const dateCell = document.createElement('td');
+  const dateInput = document.createElement('input');
+  dateInput.type = 'date';
+  dateInput.classList.add('purchase-date');
+  dateInput.value = data.date || '';
+  dateCell.appendChild(dateInput);
+  row.appendChild(dateCell);
 
-  const usdCell = document.createElement('td');
-  usdCell.textContent = '-';
-  row.appendChild(usdCell);
+  const amountCell = document.createElement('td');
+  const amountInput = document.createElement('input');
+  amountInput.type = 'number';
+  amountInput.step = 'any';
+  amountInput.classList.add('amount');
+  amountInput.value = data.amount || '';
+  amountCell.appendChild(amountInput);
+  row.appendChild(amountCell);
+
+  const priceCell = document.createElement('td');
+  const priceInput = document.createElement('input');
+  priceInput.type = 'number';
+  priceInput.step = 'any';
+  priceInput.classList.add('price');
+  priceInput.value = data.price || '';
+  priceCell.appendChild(priceInput);
+  row.appendChild(priceCell);
+
+  const currencyCell = document.createElement('td');
+  const currencySelect = document.createElement('select');
+  currencySelect.classList.add('currency');
+  ['eur', 'usd'].forEach(cur => {
+    const option = document.createElement('option');
+    option.value = cur;
+    option.textContent = cur.toUpperCase();
+    if ((data.currency || 'eur') === cur) {
+      option.selected = true;
+    }
+    currencySelect.appendChild(option);
+  });
+  currencyCell.appendChild(currencySelect);
+  row.appendChild(currencyCell);
+
+  const costCell = document.createElement('td');
+  costCell.textContent = '-';
+  row.appendChild(costCell);
+
+  const currentCell = document.createElement('td');
+  currentCell.textContent = '-';
+  row.appendChild(currentCell);
+
+  const diffCell = document.createElement('td');
+  diffCell.textContent = '-';
+  row.appendChild(diffCell);
+
+  const percentCell = document.createElement('td');
+  percentCell.textContent = '-';
+  row.appendChild(percentCell);
 
   function update() {
     const crypto = nameSelect.value.trim().toLowerCase();
-    if (!crypto) {
-      eurCell.textContent = '-';
-      usdCell.textContent = '-';
+    const amount = parseFloat(amountInput.value);
+    const price = parseFloat(priceInput.value);
+    const currency = currencySelect.value;
+
+    if (!crypto || isNaN(amount) || isNaN(price)) {
+      costCell.textContent = '-';
+      currentCell.textContent = '-';
+      diffCell.textContent = '-';
+      percentCell.textContent = '-';
+      row.dataset.cost = 0;
+      row.dataset.value = 0;
       savePortfolio();
+      updateTotals();
       return;
     }
-    fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${crypto}&vs_currencies=eur,usd`)
+
+    const cost = amount * price;
+    costCell.textContent = cost.toFixed(2);
+
+    fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${crypto}&vs_currencies=${currency}`)
       .then(res => res.json())
       .then(data => {
         if (data[crypto]) {
-          eurCell.textContent = data[crypto].eur;
-          usdCell.textContent = data[crypto].usd;
+          const currentPrice = data[crypto][currency];
+          const currentValue = currentPrice * amount;
+          const diff = currentValue - cost;
+          const percent = cost ? (diff / cost) * 100 : 0;
+          currentCell.textContent = currentValue.toFixed(2);
+          diffCell.textContent = diff.toFixed(2);
+          percentCell.textContent = percent.toFixed(2) + '%';
+          row.dataset.cost = cost;
+          row.dataset.value = currentValue;
         } else {
-          eurCell.textContent = 'N/A';
-          usdCell.textContent = 'N/A';
+          currentCell.textContent = 'N/A';
+          diffCell.textContent = 'N/A';
+          percentCell.textContent = 'N/A';
+          row.dataset.cost = cost;
+          row.dataset.value = 0;
         }
       })
       .catch(() => {
-        eurCell.textContent = 'Err';
-        usdCell.textContent = 'Err';
+        currentCell.textContent = 'Err';
+        diffCell.textContent = 'Err';
+        percentCell.textContent = 'Err';
+        row.dataset.cost = cost;
+        row.dataset.value = 0;
       })
-      .finally(savePortfolio);
+      .finally(() => {
+        savePortfolio();
+        updateTotals();
+      });
   }
 
-  nameSelect.addEventListener('change', update);
+  [nameSelect, dateInput, amountInput, priceInput, currencySelect].forEach(el => {
+    el.addEventListener('change', update);
+  });
+
   tbody.appendChild(row);
 
-  if (name) {
+  if (data.id) {
     update();
   }
 }
@@ -87,9 +195,11 @@ addBtn.addEventListener('click', () => addRow());
       coinList = data;
       const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
       if (saved.length) {
-        saved.forEach(name => addRow(name));
+        saved.forEach(item => addRow(item));
       } else {
         addRow();
       }
+      updateTotals();
     });
 })();
+


### PR DESCRIPTION
## Summary
- Track detailed crypto purchases with date, quantity, price and currency
- Show current value, profit/loss and totals per currency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6de806584832aa5412fb01991955d