### PR TITLE
Cache crypto list and integrate purchases with portfolio

### DIFF
--- a/public/achat.html
+++ b/public/achat.html
@@ -20,6 +20,9 @@
     <label>Prix (EUR):
       <input type="number" id="price" step="any" required />
     </label>
+    <label>Montant total (EUR):
+      <input type="number" id="total" step="any" readonly />
+    </label>
     <button type="submit">Ajouter</button>
   </form>
 
@@ -30,6 +33,7 @@
         <th>Crypto</th>
         <th>Quantité</th>
         <th>Prix (EUR)</th>
+        <th>Total (EUR)</th>
       </tr>
     </thead>
     <tbody id="purchases-body"></tbody>

--- a/public/js/achat.js
+++ b/public/js/achat.js
@@ -1,7 +1,24 @@
 const select = document.getElementById('crypto-select');
 const form = document.getElementById('achat-form');
 const body = document.getElementById('purchases-body');
+const quantityInput = document.getElementById('quantity');
+const priceInput = document.getElementById('price');
+const totalInput = document.getElementById('total');
 let coinList = [];
+
+function getCoinList() {
+  const cached = localStorage.getItem('coinList');
+  if (cached) {
+    coinList = JSON.parse(cached);
+    return Promise.resolve();
+  }
+  return fetch('https://api.coingecko.com/api/v3/coins/list')
+    .then(res => res.json())
+    .then(data => {
+      coinList = data;
+      localStorage.setItem('coinList', JSON.stringify(data));
+    });
+}
 
 function populateSelect() {
   const emptyOption = document.createElement('option');
@@ -21,12 +38,13 @@ function save() {
   const purchases = Array.from(body.querySelectorAll('tr')).map(row => ({
     crypto: row.children[0].textContent,
     quantity: row.children[1].textContent,
-    price: row.children[2].textContent
+    price: row.children[2].textContent,
+    total: row.children[3].textContent
   }));
   localStorage.setItem('purchases', JSON.stringify(purchases));
 }
 
-function addRow({ crypto, quantity, price }) {
+function addRow({ crypto, quantity, price, total }) {
   const row = document.createElement('tr');
   const cCell = document.createElement('td');
   cCell.textContent = crypto;
@@ -37,29 +55,44 @@ function addRow({ crypto, quantity, price }) {
   const pCell = document.createElement('td');
   pCell.textContent = price;
   row.appendChild(pCell);
+  const tCell = document.createElement('td');
+  tCell.textContent = total;
+  row.appendChild(tCell);
   body.appendChild(row);
 }
+
+function updateTotal() {
+  const q = parseFloat(quantityInput.value) || 0;
+  const p = parseFloat(priceInput.value) || 0;
+  totalInput.value = (q * p).toFixed(2);
+}
+
+quantityInput.addEventListener('input', updateTotal);
+priceInput.addEventListener('input', updateTotal);
 
 form.addEventListener('submit', e => {
   e.preventDefault();
   const crypto = select.value.trim();
-  const quantity = document.getElementById('quantity').value;
-  const price = document.getElementById('price').value;
+  const quantity = quantityInput.value;
+  const price = priceInput.value;
+  const total = totalInput.value;
   if (!crypto || !quantity || !price) return;
 
   const symbol = select.options[select.selectedIndex].textContent;
-  addRow({ crypto: symbol, quantity, price });
+  addRow({ crypto: symbol, quantity, price, total });
   save();
+  const portfolio = JSON.parse(localStorage.getItem('portfolio') || '[]');
+  portfolio.push({ id: crypto, date: new Date().toISOString().slice(0,10), amount: quantity, price, currency: 'eur' });
+  localStorage.setItem('portfolio', JSON.stringify(portfolio));
   form.reset();
+  updateTotal();
 });
 
 (function init() {
-  fetch('https://api.coingecko.com/api/v3/coins/list')
-    .then(res => res.json())
-    .then(data => {
-      coinList = data;
-      populateSelect();
-      const saved = JSON.parse(localStorage.getItem('purchases') || '[]');
-      saved.forEach(addRow);
-    });
+  getCoinList().then(() => {
+    populateSelect();
+    const saved = JSON.parse(localStorage.getItem('purchases') || '[]');
+    saved.forEach(addRow);
+    updateTotal();
+  });
 })();

--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -3,6 +3,20 @@ const addBtn = document.getElementById('add-crypto');
 const saveBtn = document.getElementById('save-portfolio');
 let coinList = [];
 
+function loadCoinList() {
+  const cached = localStorage.getItem('coinList');
+  if (cached) {
+    coinList = JSON.parse(cached);
+    return Promise.resolve();
+  }
+  return fetch('https://api.coingecko.com/api/v3/coins/list')
+    .then(res => res.json())
+    .then(data => {
+      coinList = data;
+      localStorage.setItem('coinList', JSON.stringify(data));
+    });
+}
+
 function savePortfolio() {
   const items = Array.from(tbody.querySelectorAll('tr')).map(row => {
     return {
@@ -191,17 +205,14 @@ addBtn.addEventListener('click', () => addRow());
 saveBtn.addEventListener('click', savePortfolio);
 
 (function init() {
-  fetch('https://api.coingecko.com/api/v3/coins/list')
-    .then(res => res.json())
-    .then(data => {
-      coinList = data;
-      const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
-      if (saved.length) {
-        saved.forEach(item => addRow(item));
-      } else {
-        addRow();
-      }
-      updateTotals();
-    });
+  loadCoinList().then(() => {
+    const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
+    if (saved.length) {
+      saved.forEach(item => addRow(item));
+    } else {
+      addRow();
+    }
+    updateTotals();
+  });
 })();
 


### PR DESCRIPTION
## Summary
- Cache cryptocurrency list in localStorage to avoid refetching on each visit.
- Automatically compute and display total EUR amount on the purchase form.
- Record purchases into the main portfolio so gains/losses show on the homepage.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c6e37d05c0832ab7d0135b2363d3c6