### PR TITLE
Enable row deletion and add styling

### DIFF
--- a/public/achat.html
+++ b/public/achat.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Achat Crypto</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <nav>
@@ -27,13 +28,14 @@
   </form>
 
   <h2>Achats enregistrés</h2>
-  <table border="1">
+  <table>
     <thead>
       <tr>
         <th>Crypto</th>
         <th>Quantité</th>
         <th>Prix (EUR)</th>
         <th>Total (EUR)</th>
+        <th>Action</th>
       </tr>
     </thead>
     <tbody id="purchases-body"></tbody>

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Portefeuille Crypto</title>
+  <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
   <nav>
@@ -11,7 +12,7 @@
   </nav>
   <h1>Portefeuille Crypto</h1>
   
-  <table border="1">
+  <table>
     <thead>
       <tr>
         <th>Crypto</th>
@@ -23,6 +24,7 @@
         <th>Valeur actuelle</th>
         <th>Différence</th>
         <th>%</th>
+        <th>Action</th>
       </tr>
     </thead>
     <tbody id="portfolio-body"></tbody>
@@ -33,6 +35,7 @@
         <th id="total-eur-value">0</th>
         <th id="total-eur-diff">0</th>
         <th id="total-eur-percent">0%</th>
+        <th></th>
       </tr>
       <tr>
         <th colspan="5">Total USD</th>
@@ -40,6 +43,7 @@
         <th id="total-usd-value">0</th>
         <th id="total-usd-diff">0</th>
         <th id="total-usd-percent">0%</th>
+        <th></th>
       </tr>
     </tfoot>
   </table>

--- a/public/js/achat.js
+++ b/public/js/achat.js
@@ -35,12 +35,15 @@ function populateSelect() {
 }
 
 function save() {
-  const purchases = Array.from(body.querySelectorAll('tr')).map(row => ({
-    crypto: row.children[0].textContent,
-    quantity: row.children[1].textContent,
-    price: row.children[2].textContent,
-    total: row.children[3].textContent
-  }));
+  const purchases = Array.from(body.querySelectorAll('tr')).map(row => {
+    const cells = row.querySelectorAll('td');
+    return {
+      crypto: cells[0].textContent,
+      quantity: cells[1].textContent,
+      price: cells[2].textContent,
+      total: cells[3].textContent
+    };
+  });
   localStorage.setItem('purchases', JSON.stringify(purchases));
 }
 
@@ -58,6 +61,18 @@ function addRow({ crypto, quantity, price, total }) {
   const tCell = document.createElement('td');
   tCell.textContent = total;
   row.appendChild(tCell);
+
+  const delCell = document.createElement('td');
+  const delBtn = document.createElement('button');
+  delBtn.textContent = 'Supprimer';
+  delBtn.classList.add('delete-btn');
+  delBtn.addEventListener('click', () => {
+    row.remove();
+    save();
+  });
+  delCell.appendChild(delBtn);
+  row.appendChild(delCell);
+
   body.appendChild(row);
 }
 

--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -135,6 +135,18 @@ function addRow(data = {}) {
   percentCell.textContent = '-';
   row.appendChild(percentCell);
 
+  const actionCell = document.createElement('td');
+  const delBtn = document.createElement('button');
+  delBtn.textContent = 'Supprimer';
+  delBtn.classList.add('delete-btn');
+  delBtn.addEventListener('click', () => {
+    row.remove();
+    savePortfolio();
+    updateTotals();
+  });
+  actionCell.appendChild(delBtn);
+  row.appendChild(actionCell);
+
   function update() {
     const crypto = nameSelect.value.trim().toLowerCase();
     const amount = parseFloat(amountInput.value);

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,43 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+  background: #f4f4f4;
+}
+
+nav {
+  margin-bottom: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 20px;
+}
+
+th, td {
+  padding: 8px;
+  border: 1px solid #ddd;
+  text-align: left;
+}
+
+th {
+  background-color: #f9f9f9;
+}
+
+button {
+  padding: 6px 12px;
+  margin-right: 5px;
+  border: none;
+  background-color: #007bff;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button.delete-btn {
+  background-color: #dc3545;
+}
+
+button:hover {
+  opacity: 0.9;
+}


### PR DESCRIPTION
## Summary
- allow deleting entries on portfolio and purchase pages
- introduce shared CSS for a modern look
- wire up deletion buttons to update totals and storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7ab60d4832a8b35046ca570aeb2