### PR TITLE
Display current prices in home table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,15 @@
 
   <section id="market-prices">
     <h2>Valeurs actuelles</h2>
-    <div id="crypto-values"></div>
+    <table>
+      <thead>
+        <tr>
+          <th>Crypto</th>
+          <th>Valeur actuelle</th>
+        </tr>
+      </thead>
+      <tbody id="crypto-values"></tbody>
+    </table>
   </section>
   
   <table>

--- a/public/js/prices.js
+++ b/public/js/prices.js
@@ -1,23 +1,27 @@
-const container = document.getElementById('crypto-values');
+const tbody = document.getElementById('crypto-values');
 const ids = ['bitcoin', 'ethereum', 'litecoin'];
 
 function refreshPrices() {
   fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${ids.join(',')}&vs_currencies=eur,usd`)
     .then(res => res.json())
     .then(data => {
-      container.innerHTML = '';
+      tbody.innerHTML = '';
       ids.forEach(id => {
         const price = data[id];
         if (price) {
-          const p = document.createElement('p');
-          const name = id.charAt(0).toUpperCase() + id.slice(1);
-          p.textContent = `${name} : ${price.eur} EUR / ${price.usd} USD`;
-          container.appendChild(p);
+          const tr = document.createElement('tr');
+          const nameTd = document.createElement('td');
+          const valueTd = document.createElement('td');
+          nameTd.textContent = id.charAt(0).toUpperCase() + id.slice(1);
+          valueTd.textContent = `${price.eur} EUR / ${price.usd} USD`;
+          tr.appendChild(nameTd);
+          tr.appendChild(valueTd);
+          tbody.appendChild(tr);
         }
       });
     })
     .catch(() => {
-      container.textContent = 'Impossible de charger les valeurs.';
+      tbody.innerHTML = '<tr><td colspan="2">Impossible de charger les valeurs.</td></tr>';
     });
 }
 


### PR DESCRIPTION
## Summary
- Show current crypto prices in a dedicated table on the home page
- Populate the table with live EUR/USD values from CoinGecko

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c6eb2175f8832abdbd5476d82afcd5