### PR TITLE
Aggregate purchases by crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # DataFollow
 Follow Crypto value
+
+## Features
+
+- Record crypto purchases on the **Achat** page. If multiple purchases are made for the same crypto, they are automatically merged and the total appears on the home portfolio table.

--- a/public/js/achat.js
+++ b/public/js/achat.js
@@ -97,7 +97,20 @@ form.addEventListener('submit', e => {
   addRow({ crypto: symbol, quantity, price, total });
   save();
   const portfolio = JSON.parse(localStorage.getItem('portfolio') || '[]');
-  portfolio.push({ id: crypto, date: new Date().toISOString().slice(0,10), amount: quantity, price, currency: 'eur' });
+  const existing = portfolio.find(
+    item => item.id === crypto && (item.currency || 'eur') === 'eur'
+  );
+  if (existing) {
+    const oldAmount = parseFloat(existing.amount) || 0;
+    const oldPrice = parseFloat(existing.price) || 0;
+    const newAmount = oldAmount + parseFloat(quantity);
+    const totalCost = oldAmount * oldPrice + parseFloat(quantity) * parseFloat(price);
+    existing.amount = newAmount.toString();
+    existing.price = (totalCost / newAmount).toString();
+    existing.date = new Date().toISOString().slice(0,10);
+  } else {
+    portfolio.push({ id: crypto, date: new Date().toISOString().slice(0,10), amount: quantity, price, currency: 'eur' });
+  }
   localStorage.setItem('portfolio', JSON.stringify(portfolio));
   form.reset();
   updateTotal();

--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -220,7 +220,33 @@ saveBtn.addEventListener('click', savePortfolio);
   loadCoinList().then(() => {
     const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
     if (saved.length) {
-      saved.forEach(item => addRow(item));
+      const grouped = {};
+      saved.forEach(item => {
+        const key = `${item.id}|${item.currency || 'eur'}`;
+        const amt = parseFloat(item.amount) || 0;
+        const price = parseFloat(item.price) || 0;
+        if (!grouped[key]) {
+          grouped[key] = {
+            id: item.id,
+            date: item.date,
+            amount: amt,
+            price,
+            currency: item.currency || 'eur'
+          };
+        } else {
+          const g = grouped[key];
+          const totalAmount = g.amount + amt;
+          const totalCost = g.amount * g.price + amt * price;
+          g.amount = totalAmount;
+          g.price = totalCost / totalAmount;
+          g.date = item.date;
+        }
+      });
+      Object.values(grouped).forEach(g => {
+        g.amount = g.amount.toString();
+        g.price = g.price.toString();
+        addRow(g);
+      });
     } else {
       addRow();
     }


### PR DESCRIPTION
## Summary
- Merge repeated crypto purchases so the home portfolio table shows combined totals
- Group portfolio data by crypto when loading the home page
- Document aggregated purchase behavior in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7114c02d8832a95ebf8ba69a3de7a