### PR TITLE
Display saved purchases on home page

### DIFF
--- a/public/js/portfolio.js
+++ b/public/js/portfolio.js
@@ -218,7 +218,32 @@ saveBtn.addEventListener('click', savePortfolio);
 
 (function init() {
   loadCoinList().then(() => {
-    const saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
+    const symbolMap = {};
+    coinList.forEach(c => {
+      symbolMap[c.symbol.toUpperCase()] = c.id;
+    });
+
+    let saved = JSON.parse(localStorage.getItem('portfolio') || '[]');
+    if (!saved.length) {
+      const purchases = JSON.parse(localStorage.getItem('purchases') || '[]');
+      if (purchases.length) {
+        saved = purchases
+          .map(p => {
+            const id = symbolMap[p.crypto];
+            if (!id) return null;
+            return {
+              id,
+              date: new Date().toISOString().slice(0, 10),
+              amount: p.quantity,
+              price: p.price,
+              currency: 'eur'
+            };
+          })
+          .filter(Boolean);
+        localStorage.setItem('portfolio', JSON.stringify(saved));
+      }
+    }
+
     if (saved.length) {
       const grouped = {};
       saved.forEach(item => {


### PR DESCRIPTION
## Summary
- Convert saved purchases into portfolio entries if portfolio is empty
- Ensure purchases appear on portfolio table on the home page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c712af2710832a98b5f730bd8403a9